### PR TITLE
Fix save! arity bug and doc typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-02-27
+### Changed
+- Updated to Neanderthal 0.53.2.
+- Updated to Nippy 3.5.0.
+- Removed obsolete JVM flag from `project.clj`.
+- Aligned example project and README with latest versions.
+
+
 ## [0.4.0] - 2020-07-26
 ## Changes
 - Updated to the Neanderthal 0.33 release.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ a factory.
 
 Add the necessary dependency to your project:
 
-```$clj
-    [neanderthal-stick "0.4.0]
+```clojure
+    [neanderthal-stick "0.5.0"]
 ```
 
 ## Usage
@@ -38,7 +38,7 @@ For reference documentation refer to the project
 [github pages](https://katox.github.io/neanderthal-stick/index.html).
 
 *Note*: The API is very early stage and subject to change thus it is
-in the `expertimental` namespace.
+in the `experimental` namespace.
 
 ### Saving to File
 

--- a/examples/def-new-kind/README.md
+++ b/examples/def-new-kind/README.md
@@ -2,7 +2,7 @@
 
 An example that shows what's needed to add a new
 kind (a deftyped structure) that can be a saved and loaded
-using [neaderthal-stick](https://github.com/katox/neanderthal-stick).
+using [neanderthal-stick](https://github.com/katox/neanderthal-stick).
 
 ## License
 

--- a/examples/def-new-kind/project.clj
+++ b/examples/def-new-kind/project.clj
@@ -1,14 +1,11 @@
-(defproject def-new-kind "0.4.0"
+(defproject def-new-kind "0.5.0-SNAPSHOT"
   :description "Save/Load Extensions for Neanderthal, Fast Clojure Matrix Library"
   :url "https://github.com/katox/neanderthal-stick"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [neanderthal-stick "0.4.0"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [neanderthal-stick "0.5.0-SNAPSHOT"]]
   :repl-options {:init-ns def-new-kind.core}
   :profiles {:java8 {:jvm-opts ^:replace ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1"]}}
-
-  :jvm-opts ["--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"]
-
   :javac-options ["-target" "1.8" "-source" "1.8" "-Xlint:-options"]
   :source-paths ["src"])

--- a/project.clj
+++ b/project.clj
@@ -17,8 +17,7 @@
           :output-path "doc/codox"}
 
   ;;also replaces lein's default JVM argument TieredStopAtLevel=1
-  :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"
-                       "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"]
+  :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]
 
   :repl-options {:init-ns neanderthal-stick.core}
 

--- a/src/neanderthal_stick/experimental.clj
+++ b/src/neanderthal_stick/experimental.clj
@@ -24,8 +24,8 @@
      (do
        (nippy/freeze-to-out! data-out (describe x))
        (transfer! x data-out))))
-  ([x data-out]
-   (save! data-out x nil)))
+   ([x data-out]
+    (save! x data-out nil)))
 
 (defn save-to-file!
   "Save the Neanderthal matrix or the vector `x` to the file path name `file-path`. Opens `file-path as data output stream,

--- a/src/neanderthal_stick/nippy_ext.clj
+++ b/src/neanderthal_stick/nippy_ext.clj
@@ -24,8 +24,8 @@
   ```
       (clojurecuda/with-default
          (with-open [in (DataInputStream. (io/input-stream (io/file \"/tmp/my_matrix.bin\")))]
-             (with-neanderthal-factory (cuda-double (current-context) default-stream)
-                 (nippy/thaw-from-in! in)))
+             (with-real-factory (cuda-double (current-context) default-stream)
+                (nippy/thaw-from-in! in)))
   ```
   "
   [factory & body]


### PR DESCRIPTION
## Summary
- fix arity delegation in `save!`
- correct example macro name in `with-real-factory` docstring
- update README typos

## Testing
- `lein midje` *(fails: lein not installed)*