### PR TITLE
Fix namespace in buffer namespace require

### DIFF
--- a/src/neanderthal_stick/internal/buffer.clj
+++ b/src/neanderthal_stick/internal/buffer.clj
@@ -13,7 +13,7 @@
             [uncomplicate.neanderthal.block :as block]
             [uncomplicate.neanderthal.core :as core :refer [transfer!]]
             [uncomplicate.neanderthal.internal.api :as api]
-            [uncomplicate.neanderthal.internal.host.buffer-block])
+            [uncomplicate.neanderthal.internal.host.buffer_block])
   (:import (java.io OutputStream InputStream DataOutput DataInput)
            (java.nio ByteBuffer)
            (java.nio.channels Channels)


### PR DESCRIPTION
## Summary
- update `buffer` namespace require to use `buffer_block`

## Testing
- `lein midje` *(fails: `lein: command not found`)*