### PR TITLE
Fix README and namespace require

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,15 @@ There is an example in the repository:
 TLDR; you need to define a new self-description ability, a constructor
 from that descriptor and the actual content save and load `transfer!` multimethods.
 
+## Running Tests
+
+Use the development profile so that the native libraries are available when
+running the test suite:
+
+```bash
+lein with-profile dev midje
+```
+
 ## License
 
 Copyright © 2019-2020 Kamil Toman

--- a/src/neanderthal_stick/internal/buffer.clj
+++ b/src/neanderthal_stick/internal/buffer.clj
@@ -13,7 +13,7 @@
             [uncomplicate.neanderthal.block :as block]
             [uncomplicate.neanderthal.core :as core :refer [transfer!]]
             [uncomplicate.neanderthal.internal.api :as api]
-            [uncomplicate.neanderthal.internal.host.buffer-block])
+            [uncomplicate.neanderthal.internal.host.buffer_block])
   (:import (java.io OutputStream InputStream DataOutput DataInput)
            (java.nio ByteBuffer)
            (java.nio.channels Channels)


### PR DESCRIPTION
## Summary
- fix namespace require
- add README instructions on running tests

## Testing
- `lein with-profile dev midje` *(fails: `lein: command not found`)*